### PR TITLE
JRuby Release & Execution Strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,21 +32,33 @@ jobs:
           echo "The current tag is: $CURR_TAG"
           ./update_version.rb $NEW_TAG
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.5
+          ruby-version: 3.1.4
           bundler-cache: false
+
+      - name: Set up JRuby and Bundler
+        run: |
+          curl 'https://repo1.maven.org/maven2/org/jruby/jruby-complete/9.4.8.0/jruby-complete-9.4.8.0.jar' \
+            --output jruby.jar
+          java -jar jruby.jar \
+            -S gem install bundler --install-dir vendor/bundle/jruby/3.1.0
 
       - name: Bundle and install dependencies
         run: |
-          bundle config set frozen false
-          bundle install --path=vendor/bundle
+          java -jar jruby.jar -s vendor/bundle/jruby/3.1.0/bin/bundle install
 
       - name: Build distribution and set Git perms
         run: |
           sudo chown -R "${USER:-$(id -un)}" .
-          gem build ruby_ast_gen.gemspec
+          java -jar jruby.jar -S gem build ruby_ast_gen.gemspec
 
       - name: Add and commit updated files holding version information
         uses: stefanzweifel/git-auto-commit-action@v5
@@ -63,4 +75,5 @@ jobs:
           GITHUB_TOKEN_PERMISSIONS: "read:packages, write:packages"
         with:
           tag_name: ${{ steps.taggerDryRun.outputs.new_tag }}
-          files: ruby_ast_gen-*.gem
+          files: |
+            ruby_ast_gen-*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_ast_gen (0.8.0)
+    ruby_ast_gen (0.9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,6 +14,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
+    racc (1.8.1-java)
     rake (13.2.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -33,6 +34,7 @@ GEM
 PLATFORMS
   arm64-darwin-24
   ruby
+  universal-java-21
 
 DEPENDENCIES
   logger (~> 1.6)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ backwards-compatible AST formats.
 
 ## Usage
 
+The release uses JRuby to enable an effective standalone version. Using `jruby`, one can run
+```
+jruby -S bundle install
+jruby -S bundle exec exe/ruby_ast_gen
+```
+
+If using the JAR file, instead you can run
+```
+curl 'https://repo1.maven.org/maven2/org/jruby/jruby-complete/9.4.8.0/jruby-complete-9.4.8.0.jar' \
+    --output jruby.jar
+java -jar jruby.jar \
+    -S gem install bundler --install-dir vendor/bundle/jruby/3.1.0
+java -jar jruby.jar -s vendor/bundle/jruby/3.1.0/bin/bundle install
+java -jar jruby.jar -S vendor/bundle/jruby/3.1.0/bin/bundle exec exe/ruby_ast_gen
+```
+
+The commands are as follows:
 ```
 usage: ruby_ast_gen [options]
     -i, --input    The input file or directory

--- a/exe/ruby_ast_gen
+++ b/exe/ruby_ast_gen
@@ -1,8 +1,5 @@
 #!/usr/bin/env ruby
 
-libs = File.expand_path("../../vendor/bundle/ruby/*/gems/**/lib", __FILE__)
-$LOAD_PATH.unshift *Dir.glob(libs)
-
 require "bundler/setup"
 require "slop"
 


### PR DESCRIPTION
Making use of JRuby and ensuring bundler + dependencies are packaged in `vendor` such that there is no need for fiddling with load path.