### PR TITLE
`KwBegin` body fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_ast_gen (0.11.0)
+    ruby_ast_gen (0.14.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/ruby_ast_gen/node_handling.rb
+++ b/lib/ruby_ast_gen/node_handling.rb
@@ -114,7 +114,7 @@ module NodeHandling
     when :begin
       base_map[:body] = children
     when :kwbegin
-      base_map[:body] = children[0]
+      base_map[:body] = children[0..-1]
     when :case
       base_map[:case_expression] = children[0]
       base_map[:when_clauses] = children[1..-2]


### PR DESCRIPTION
Fixed `body` for `kwbegin` to include all children, not just first.