### PR TITLE
Increase character limit for extracted code.

### DIFF
--- a/lib/ruby_ast_gen/node_handling.rb
+++ b/lib/ruby_ast_gen/node_handling.rb
@@ -71,7 +71,7 @@ module NodeHandling
     range = location.expression || location
     return nil unless range.is_a?(Parser::Source::Range)
     snippet = source_code[range.begin_pos...range.end_pos]
-    self.truncate_string(snippet.strip, 60)
+    self.truncate_string(snippet.strip, 90)
   end
 
   def self.add_node_properties(node_type, base_map, file_path)


### PR DESCRIPTION
Currently, extracted code is truncated at 60 characters. I have increased this to 90 to aid in ruby endpoint detection.