### PR TITLE
WIP: Convert ERB files to Ruby structures that can generate AST

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem "ostruct", "~> 0.6.0"
 gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
+
+gem "temple"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ also run `bin/console` for an interactive prompt that will allow you to experime
 
 To install this gem onto your local machine, run `bundle exec rake install`. To package, run `rake build`.
 
+If you are switching between native `ruby` and `jruby` or vice versa, make sure to delete the `vendor` folder before running `jruby -S bundle install` otherwise there will be a clash
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/ruby_ast_gen/ErbToRubyTransformer.rb
+++ b/lib/ruby_ast_gen/ErbToRubyTransformer.rb
@@ -1,0 +1,126 @@
+require 'temple'
+require 'erb'
+
+class ErbToRubyTransformer
+  def initialize
+    @parser = Temple::ERB::Parser.new
+    @indent_level = 0
+    @current_line = []
+    @in_control_block = false
+    @control_block_content = []
+  end
+
+  def call(input)
+    ast = @parser.call(input)
+    content = visit(ast)
+    # Wrap everything in a HEREDOC
+    <<~RUBY
+      <<~HEREDOC
+      #{content}
+      HEREDOC
+    RUBY
+  end
+
+  private
+  def visit(node)
+    return "" unless node.is_a?(Array)
+
+    case node.first
+    when :multi
+      # Usually the start of an ERB program
+      output = []
+      node[1..-1].each do |child|
+        transformed = visit(child)
+        if transformed.strip.empty?
+          flush_current_line(output) unless @current_line.empty?
+        else
+          @current_line << transformed
+        end
+      end
+      flush_current_line(output) unless @current_line.empty?
+      output.join("\n")
+    when :static
+      text = node[1].to_s
+      return "" if text.strip.empty?
+      if @in_control_block
+        # In control blocks, we need to escape newlines and maintain indentation
+        escaped_text = text.strip.gsub("\n", "\\n")
+        @control_block_content << "#{escaped_text}"
+        ""  # Return empty string as we're collecting content
+      else
+        "#{indent}#{text}"
+      end
+    when :dynamic
+      # Handles <%= %> tags
+      code = node[1].to_s.strip
+      if @in_control_block
+        @control_block_content << "\#{#{code}}"
+        ""
+      else
+        "\#{#{code}}"
+      end
+    when :escape
+      escape_enabled = node[1]
+      inner_node = node[2]
+      visit(inner_node)
+    when :code
+      # Handles <% %> tags
+      code = node[1].to_s.strip
+      if code.start_with?('if', 'unless', 'else', 'elsif', 'end')
+        if code.start_with?('if', 'unless')
+          @in_control_block = true
+          @control_block_content = []
+          flush_current_line(@current_line) unless @current_line.empty?
+          "\#{#{code}"
+        elsif code == 'end'
+          @in_control_block = false
+          # Join all collected content and wrap in quotes
+          content = @control_block_content.join
+          @control_block_content = []
+          "\"#{content}\"#{code}}"
+        else
+          # else, elsif
+          content = @control_block_content.join
+          @control_block_content = []
+          "\"#{content}\"#{code}"
+        end
+      else
+        if @in_control_block
+          @control_block_content << "#{code}"
+          ""
+        else
+          "\#{#{code}}"
+        end
+      end
+    else
+      if node.is_a?(Array) && node.length > 1
+        node[1..-1].map { |child| visit(child) }.join
+      else
+        ""
+      end
+    end
+  end
+
+  def indent
+    "  " * @indent_level
+  end
+
+  def flush_current_line(output)
+    unless @current_line.empty?
+      line = @current_line.join.rstrip
+      output << line unless line.empty?
+      @current_line.clear
+    end
+  end
+end
+
+# class ErbToRubyTransformer < Temple::Engine
+#   use Temple::ERB::Parser
+#   use Temple::ERB::Trimming
+#   generator :RubyCodeGenerator
+#
+#   def call(input)
+#     compiled = super
+#     compiled.split("\n").reject(&:empty?).join("\n")
+#   end
+# end


### PR DESCRIPTION
* Attempts to convert `ERB` file to a HEREDOC string that can be parsed and an AST can be generated from
* Falls back to wrapping the entire file in a `HEREDOC` if the transformation fails

```ruby
app_name: <%= ENV['APP_NAME'] %>
version: <%= ENV['APP_VERSION'] %>

database:
  host: <%= ENV['DB_HOST'] %>
  port: <%= ENV['DB_PORT'] %>

<% if ENV['USE_REDIS'] == 'true' %>
redis:
  host: <%= ENV['REDIS_HOST'] %>
  port: <%= ENV['REDIS_PORT'] %>
<% end %>
```
Gets converted to:
```ruby
<<~HEREDOC
  app_name: #{ENV['APP_NAME']}
  version: #{ENV['APP_VERSION']}
  database:
    host: #{ENV['DB_HOST']}
    port: #{ENV['DB_PORT']}
  #{
    if ENV['USE_REDIS'] == 'true'
      "redis:\n  host: #{ENV['REDIS_HOST']}\n  port: #{ENV['REDIS_PORT']}"
    else
      ""
    end
  }
HEREDOC
```