### PR TITLE
ERB transformation rework

### DIFF
--- a/lib/ruby_ast_gen.rb
+++ b/lib/ruby_ast_gen.rb
@@ -124,7 +124,6 @@ module RubyAstGen
         file_content = File.read(file_path)
         get_erb_content(file_content)
       end
-    puts code
     buffer = Parser::Source::Buffer.new(file_path)
     buffer.source = code
     parser = Parser::CurrentRuby.new

--- a/lib/ruby_ast_gen.rb
+++ b/lib/ruby_ast_gen.rb
@@ -124,6 +124,7 @@ module RubyAstGen
         file_content = File.read(file_path)
         get_erb_content(file_content)
       end
+    puts code
     buffer = Parser::Source::Buffer.new(file_path)
     buffer.source = code
     parser = Parser::CurrentRuby.new

--- a/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
+++ b/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
@@ -46,7 +46,7 @@ class ErbToRubyTransformer
       end
     when :escape
       unless @static_buff.empty?
-        buffer_to_use = if @in_do_block then "#{@inner_buffer}" else "buffer" end
+        buffer_to_use = if @in_do_block then "#{@inner_buffer}" else "#{@output_tmp_var}" end
         @output << "#{buffer_to_use} << \"#{@static_buff.join('\n').gsub(/(?<!\\)"/, '')}\""
         @static_buff = [] # clear static buffer
       end
@@ -81,7 +81,7 @@ class ErbToRubyTransformer
           @in_do_block = false
           @output << "#{@inner_buffer}"
           @output << "end"
-          @output << "buffer << #{current_lambda}.call(#{@current_lambda_vars})"
+          @output << "#{@output_tmp_var} << #{current_lambda}.call(#{@current_lambda_vars})"
         else
           @in_control_block = false
           @output << "end"

--- a/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
+++ b/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
@@ -5,9 +5,9 @@ class ErbToRubyTransformer
   def initialize
     @parser = Temple::ERB::Parser.new
     @in_control_block = false
-    @output_tmp_var = "buffer"
+    @output_tmp_var = "joern__buffer"
     @in_do_block = false
-    @inner_buffer = "inner_buffer"
+    @inner_buffer = "joern__inner_buffer"
     @current_counter = 0
     @current_lambda_vars = ""
     @output = []


### PR DESCRIPTION
Rework ERB transformation:
 * When we encounter a `<%= function_call do |some_var| %>`:
    - Add a `buffer << function_call(args)`
    - Extract the do block as a lambda, assign it to a variable (`rails_lambda_<x>`)
    - Add `buffer << rails_lambda_<x>.call(lambdaArgs)`
 * Instead of having HEREDOC's, we now append (`<<`) strings / calls to a `buffer` var
