### PR TITLE
[erb] Use `stripped_code` when checking `end` blocks

### DIFF
--- a/lib/ruby_ast_gen.rb
+++ b/lib/ruby_ast_gen.rb
@@ -154,6 +154,7 @@ module RubyAstGen
       transformer = ErbToRubyTransformer.new
       transformer.transform(file_content)
     rescue StandardError => e
+      RubyAstGen::Logger::debug "Failed to lower ERB: #{e}"
       # Wrap the file_content in HEREDOC so the AST parser gives a String output of the ERB file
       # in case the transformation fell over
       <<~RUBY

--- a/lib/ruby_ast_gen.rb
+++ b/lib/ruby_ast_gen.rb
@@ -124,6 +124,7 @@ module RubyAstGen
         file_content = File.read(file_path)
         get_erb_content(file_content)
       end
+    RubyAstGen::Logger::debug "code: #{code}"
     buffer = Parser::Source::Buffer.new(file_path)
     buffer.source = code
     parser = Parser::CurrentRuby.new

--- a/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
+++ b/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
@@ -71,11 +71,13 @@ class ErbToRubyTransformer
         @output << "#{buffer_to_use} << \"#{@static_buff.join('\n').gsub(/(?<!\\)"/, '')}\""
         @static_buff = [] # clear static buffer
       end
-      code = node[1].to_s.strip
+
+      stripped_code = node[1].to_s.strip
+      code = node[1].to_s
       # Using this to determine if we should throw a StandardError for "invalid" ERB
-      if is_control_struct_start(code)
+      if is_control_struct_start(stripped_code)
         @in_control_block = true
-        @output << code
+        @output << stripped_code
       elsif code.start_with?("end")
         if @in_do_block
           @in_do_block = false

--- a/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
+++ b/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
@@ -53,7 +53,7 @@ class ErbToRubyTransformer
 
       escape_enabled = node[1]
       inner_node = node[2]
-      code = inner_node[1].to_s.strip
+      code = inner_node[1].to_s
 
       # Do block with variable found, lower
       if is_do_block(code)

--- a/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
+++ b/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
@@ -78,7 +78,7 @@ class ErbToRubyTransformer
       if is_control_struct_start(stripped_code)
         @in_control_block = true
         @output << stripped_code
-      elsif code.start_with?("end")
+      elsif stripped_code.start_with?("end")
         if @in_do_block
           @in_do_block = false
           @output << "#{@inner_buffer}"
@@ -114,7 +114,7 @@ class ErbToRubyTransformer
   end
 
   def lower_do_block(code)
-    if (code_match = code.match(/do\s+(?:\|([^|]*)\|)?/))
+    if (code_match = code.match(/do\s+(?:\|([^|]*)\|)?/) || code.end_with?('do'))
       @current_lambda_vars = code_match[1]
       before_do, _ = code.split(/\bdo\b/)
       unless before_do.nil?


### PR DESCRIPTION
* Added debug logger for when lowering fails
* Changed the `end` check to use `stripped_code` instead of `code`.
