### PR TITLE
[ruby] Set lineNumbers to -1 when processing ERB file

### DIFF
--- a/lib/ruby_ast_gen.rb
+++ b/lib/ruby_ast_gen.rb
@@ -117,10 +117,12 @@ module RubyAstGen
   end
 
   def self.parse_file(file_path, relative_input_path)
+    isErb = false
     code =
       if ruby_file?(file_path)
         File.read(file_path)
       else
+        isErb = true
         file_content = File.read(file_path)
         get_erb_content(file_content)
       end
@@ -130,7 +132,7 @@ module RubyAstGen
     parser = Parser::CurrentRuby.new
     ast = parser.parse(buffer)
     return unless ast
-    json_ast = NodeHandling::ast_to_json(ast, code, file_path: relative_input_path)
+    json_ast = NodeHandling::ast_to_json(ast, code, file_path: relative_input_path, isErb: isErb)
     json_ast[:file_path] = file_path
     json_ast[:rel_file_path] = relative_input_path
     json_ast

--- a/lib/ruby_ast_gen.rb
+++ b/lib/ruby_ast_gen.rb
@@ -117,12 +117,12 @@ module RubyAstGen
   end
 
   def self.parse_file(file_path, relative_input_path)
-    isErb = false
+    is_erb = false
     code =
       if ruby_file?(file_path)
         File.read(file_path)
       else
-        isErb = true
+        is_erb = true
         file_content = File.read(file_path)
         get_erb_content(file_content)
       end
@@ -132,7 +132,7 @@ module RubyAstGen
     parser = Parser::CurrentRuby.new
     ast = parser.parse(buffer)
     return unless ast
-    json_ast = NodeHandling::ast_to_json(ast, code, file_path: relative_input_path, isErb: isErb)
+    json_ast = NodeHandling::ast_to_json(ast, code, file_path: relative_input_path, is_erb: is_erb)
     json_ast[:file_path] = file_path
     json_ast[:rel_file_path] = relative_input_path
     json_ast

--- a/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
+++ b/lib/ruby_ast_gen/erb_to_ruby_transformer.rb
@@ -142,7 +142,6 @@ class ErbToRubyTransformer
           @output << code
         end
       end
-      # Using this to determine if we should throw a StandardError for "invalid" ERB
     when :newline
     else
       RubyAstGen::Logger::debug("Invalid node type: #{node}")

--- a/lib/ruby_ast_gen/node_handling.rb
+++ b/lib/ruby_ast_gen/node_handling.rb
@@ -25,15 +25,15 @@ module NodeHandling
     loc.public_send(method) rescue -1
   end
 
-  def self.ast_to_json(node, code, current_depth: 0, file_path: nil)
+  def self.ast_to_json(node, code, current_depth: 0, file_path: nil, isErb: false)
     return unless node.is_a?(Parser::AST::Node)
 
     loc = node.location
     meta_data = {
-      start_line: fetch_member(loc, :line),
-      start_column: fetch_member(loc, :column),
-      end_line: fetch_member(loc, :last_line),
-      end_column: fetch_member(loc, :last_column),
+      start_line: isErb ? -1 : fetch_member(loc, :line),
+      start_column: isErb ? -1 : fetch_member(loc, :column),
+      end_line: isErb ? -1 : fetch_member(loc, :last_line),
+      end_column: isErb ? -1 : fetch_member(loc, :last_column),
       offset_start: loc&.expression&.begin_pos,
       offset_end: loc&.expression&.end_pos,
       code: self.extract_code_snippet(loc, code)

--- a/lib/ruby_ast_gen/node_handling.rb
+++ b/lib/ruby_ast_gen/node_handling.rb
@@ -25,7 +25,7 @@ module NodeHandling
     loc.public_send(method) rescue -1
   end
 
-  def self.ast_to_json(node, code, current_depth: 0, file_path: nil, isErb: false)
+  def self.ast_to_json(node, code, current_depth: 0, file_path: nil, is_erb: false)
     return unless node.is_a?(Parser::AST::Node)
 
     loc = node.location
@@ -48,7 +48,7 @@ module NodeHandling
       meta_data: meta_data,
       children: node.children.map do |child|
         if child.is_a?(Parser::AST::Node)
-          ast_to_json(child, code, current_depth: current_depth + 1, file_path: file_path) # Recursively process child nodes
+          ast_to_json(child, code, current_depth: current_depth + 1, file_path: file_path, is_erb: is_erb) # Recursively process child nodes
         else
           child # If it's not a node (e.g., literal), return as-is
         end

--- a/lib/ruby_ast_gen/node_handling.rb
+++ b/lib/ruby_ast_gen/node_handling.rb
@@ -30,10 +30,10 @@ module NodeHandling
 
     loc = node.location
     meta_data = {
-      start_line: isErb ? -1 : fetch_member(loc, :line),
-      start_column: isErb ? -1 : fetch_member(loc, :column),
-      end_line: isErb ? -1 : fetch_member(loc, :last_line),
-      end_column: isErb ? -1 : fetch_member(loc, :last_column),
+      start_line: is_erb ? -1 : fetch_member(loc, :line),
+      start_column: is_erb ? -1 : fetch_member(loc, :column),
+      end_line: is_erb ? -1 : fetch_member(loc, :last_line),
+      end_column: is_erb ? -1 : fetch_member(loc, :last_column),
       offset_start: loc&.expression&.begin_pos,
       offset_end: loc&.expression&.end_pos,
       code: self.extract_code_snippet(loc, code)


### PR DESCRIPTION
Set lineNumbers to -1 when processing ERB files so that Joern doesn't set any line numbers.